### PR TITLE
change handler to return disposition action rather than error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ handleErr(err)
 
 // Receive message from queue
 listenHandle, err := q.Receive(context.Background(), 
-	func(ctx context.Context, event *servicebus.Event) error {
-		fmt.Println(string(event.Data))
-		return nil
+	func(ctx context.Context, msg *servicebus.Message) servicebus.DispositionAction {
+		fmt.Println(string(msg.Data))
+		return msg.Accept()
 	})
 handleErr(err)
 defer listenHandle.Close(context.Background)

--- a/_examples/helloworld/consumer/main.go
+++ b/_examples/helloworld/consumer/main.go
@@ -29,7 +29,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	listenHandle, err := q.Receive(ctx, func(ctx context.Context, event *servicebus.Message) error {
+	listenHandle, err := q.Receive(ctx, func(ctx context.Context, event *servicebus.Message) servicebus.DispositionAction {
 		text := string(event.Data)
 		if text == "exit\n" {
 			fmt.Println("Oh snap!! Someone told me to exit!")
@@ -37,7 +37,7 @@ func main() {
 		} else {
 			fmt.Println(string(event.Data))
 		}
-		return nil
+		return event.Accept()
 	})
 	defer listenHandle.Close(context.Background())
 

--- a/namespace.go
+++ b/namespace.go
@@ -62,7 +62,7 @@ type (
 	}
 
 	// Handler is the function signature for any receiver of AMQP messages
-	Handler func(context.Context, *Message) error
+	Handler func(context.Context, *Message) DispositionAction
 
 	// NamespaceOption provides structure for configuring a new Service Bus namespace
 	NamespaceOption func(h *Namespace) error

--- a/queue.go
+++ b/queue.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
-		"io/ioutil"
+	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"

--- a/sender.go
+++ b/sender.go
@@ -204,7 +204,7 @@ func (s *sender) newSessionAndLink(ctx context.Context) error {
 
 	amqpSender, err := amqpSession.NewSender(
 		amqp.LinkTargetAddress(s.getAddress()),
-		amqp.LinkReceiverSettle(amqp.ModeSecond))
+		amqp.LinkSenderSettle(amqp.ModeUnsettled))
 	if err != nil {
 		log.For(ctx).Error(err)
 		return err

--- a/subscription.go
+++ b/subscription.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
-		"io/ioutil"
+	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
@@ -141,7 +141,7 @@ func (sm *SubscriptionManager) Put(ctx context.Context, name string, opts ...Sub
 			AtomSchema:                atomSchema,
 		},
 		Content: &subscriptionContent{
-			Type:                    applicationXML,
+			Type: applicationXML,
 			SubscriptionDescription: *sd,
 		},
 	}
@@ -231,7 +231,7 @@ func (sm *SubscriptionManager) Get(ctx context.Context, name string) (*Subscript
 func subscriptionEntryToEntity(entry *subscriptionEntry) *SubscriptionEntity {
 	return &SubscriptionEntity{
 		SubscriptionDescription: &entry.Content.SubscriptionDescription,
-		Name:                    entry.Title,
+		Name: entry.Title,
 	}
 }
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -287,9 +287,9 @@ func testSubscriptionReceive(ctx context.Context, t *testing.T, topic *Topic, su
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	_, err = sub.Receive(ctx, func(eventCtx context.Context, evt *Message) error {
+	_, err = sub.Receive(ctx, func(eventCtx context.Context, evt *Message) DispositionAction {
 		wg.Done()
-		return nil
+		return evt.Accept()
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/tracing.go
+++ b/tracing.go
@@ -37,6 +37,19 @@ func (ns *Namespace) startSpanFromContext(ctx context.Context, operationName str
 	return span, ctx
 }
 
+func (m *Message) startSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, operationName, opts...)
+	ApplyComponentInfo(span)
+	span.SetTag("amqp.message-id", m.ID)
+	if m.GroupID != nil {
+		span.SetTag("amqp.message-group-id", *m.GroupID)
+	}
+	if m.GroupSequence != nil {
+		span.SetTag("amqp.message-group-sequence", *m.GroupSequence)
+	}
+	return span, ctx
+}
+
 func (em *EntityManager) startSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, operationName, opts...)
 	ApplyComponentInfo(span)


### PR DESCRIPTION
Change the receiver handler signature to return a `DispositionAction` rather than error. The goal here is to increase developer awareness of dispositions and how messages will be handled. In the case of nil returned, the message is accepted.

This functionality may seem verbose for a developer that doesn't need message dispositions, but I think there are many more developer who will use message dispositions with Service Bus than without.