### PR TITLE
start spans on entity new methods

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -347,6 +347,9 @@ func queueEntryToEntity(entry *queueEntry) *QueueEntity {
 
 // NewQueue creates a new Queue Sender / Receiver
 func (ns *Namespace) NewQueue(ctx context.Context, name string, opts ...QueueOption) (*Queue, error) {
+	span, ctx := ns.startSpanFromContext(ctx, "sb.Namespace.NewQueue")
+	defer span.Finish()
+
 	qm := ns.NewQueueManager()
 	qe, err := qm.Get(ctx, name)
 	if err != nil {

--- a/subscription.go
+++ b/subscription.go
@@ -241,6 +241,9 @@ func (sm *SubscriptionManager) getResourceURI(name string) string {
 
 // NewSubscription creates a new Topic Subscription client
 func (t *Topic) NewSubscription(ctx context.Context, name string, opts ...SubscriptionOption) (*Subscription, error) {
+	span, ctx := t.startSpanFromContext(ctx, "sb.Topic.NewSubscription")
+	defer span.Finish()
+
 	sm := t.NewSubscriptionManager()
 	qe, err := sm.Get(ctx, name)
 	if err != nil {

--- a/topic.go
+++ b/topic.go
@@ -235,6 +235,9 @@ func topicEntryToEntity(entry *topicEntry) *TopicEntity {
 
 // NewTopic creates a new Topic Sender
 func (ns *Namespace) NewTopic(ctx context.Context, name string, opts ...TopicOption) (*Topic, error) {
+	span, ctx := ns.startSpanFromContext(ctx, "sb.Namespace.NewTopic")
+	defer span.Finish()
+
 	tm := ns.NewTopicManager()
 	qe, err := tm.Get(ctx, name)
 	if err != nil {


### PR DESCRIPTION
Missed adding span tracing to `New{Entity}` methods; correcting that.