### PR TITLE
Stripping away context from NewQueue constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	// Send message to the Queue named helloworld
-	err = q.Send(context.Background(), servicebus.NewMessageFromString("Hello World!"))
+	err = q.Send(servicebus.NewMessageFromString("Hello World!"))
 	if err != nil {
 		// handle message send error
 	}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ func main() {
 
 	// Initialize and create a Service Bus Queue named helloworld if it doesn't exist
 	queueName := "helloworld"
-	q, err := ns.NewQueue(context.Background(), queueName)
+	q, err := ns.NewQueue(queueName)
 	if err != nil {
 		// handle queue creation error
 	}

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	// Send message to the Queue named helloworld
-	err = q.Send(servicebus.NewMessageFromString("Hello World!"))
+	err = q.Send(context.Background(), servicebus.NewMessageFromString("Hello World!"))
 	if err != nil {
 		// handle message send error
 	}

--- a/_examples/helloworld/consumer/main.go
+++ b/_examples/helloworld/consumer/main.go
@@ -76,7 +76,7 @@ func getQueue(ns *servicebus.Namespace, queueName string) (*servicebus.Queue, er
 		}
 	}
 
-	q, err := ns.NewQueue(ctx, queueName)
+	q, err := ns.NewQueue(queueName)
 	return q, err
 }
 

--- a/_examples/helloworld/producer/main.go
+++ b/_examples/helloworld/producer/main.go
@@ -42,7 +42,7 @@ func main() {
 func getQueue(ns *servicebus.Namespace, queueName string) (*servicebus.Queue, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	q, err := ns.NewQueue(ctx, queueName)
+	q, err := ns.NewQueue(queueName)
 	return q, err
 }
 

--- a/_examples/opentracing/main.go
+++ b/_examples/opentracing/main.go
@@ -47,7 +47,7 @@ func main() {
 	listenHandle, err := q.Receive(context.Background(),
 		func(ctx context.Context, msg *servicebus.Message) servicebus.DispositionAction {
 			fmt.Println(string(msg.Data))
-			defer func(){
+			defer func() {
 				done <- nil
 			}()
 			return msg.Complete()
@@ -90,6 +90,6 @@ func startOpenTracing() (io.Closer, error) {
 func getQueue(ns *servicebus.Namespace, queueName string) (*servicebus.Queue, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	q, err := ns.NewQueue(ctx, queueName)
+	q, err := ns.NewQueue(queueName)
 	return q, err
 }

--- a/queue.go
+++ b/queue.go
@@ -424,10 +424,7 @@ func QueueWithReceiveAndDelete() QueueOption {
 //}
 
 // NewQueue creates a new Queue Sender / Receiver
-func (ns *Namespace) NewQueue(ctx context.Context, name string, opts ...QueueOption) (*Queue, error) {
-	span, ctx := ns.startSpanFromContext(ctx, "sb.Namespace.NewQueue")
-	defer span.Finish()
-
+func (ns *Namespace) NewQueue(name string, opts ...QueueOption) (*Queue, error) {
 	queue := &Queue{
 		entity: &entity{
 			namespace: ns,
@@ -438,7 +435,6 @@ func (ns *Namespace) NewQueue(ctx context.Context, name string, opts ...QueueOpt
 
 	for _, opt := range opts {
 		if err := opt(queue); err != nil {
-			log.For(ctx).Error(err)
 			return nil, err
 		}
 	}

--- a/queue_test.go
+++ b/queue_test.go
@@ -152,7 +152,7 @@ func (suite *serviceBusSuite) TestQueueManagementPopulatedQueue() {
 				suite.T().Fatal(err)
 			}
 
-			q, err := ns.NewQueue(ctx, queueName)
+			q, err := ns.NewQueue(queueName)
 			if err != nil {
 				suite.T().Fatal(err)
 			}
@@ -428,7 +428,7 @@ func (suite *serviceBusSuite) TestQueueClient() {
 			cleanup := makeQueue(ctx, t, ns, queueName,
 				QueueEntityWithPartitioning(),
 				QueueEntityWithDuplicateDetection(&window))
-			q, err := ns.NewQueue(ctx, queueName)
+			q, err := ns.NewQueue(queueName)
 			suite.NoError(err)
 			defer func() {
 				q.Close(ctx)
@@ -631,7 +631,7 @@ func (suite *serviceBusSuite) TestQueueWithReceiveAndDelete() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 			cleanup := makeQueue(ctx, t, ns, queueName)
-			q, err := ns.NewQueue(ctx, queueName, QueueWithReceiveAndDelete())
+			q, err := ns.NewQueue(queueName, QueueWithReceiveAndDelete())
 			suite.NoError(err)
 			defer func() {
 				cleanup()


### PR DESCRIPTION
Nothing is hitting the wire anymore, removing the context from the Queue constructor.