### PR TITLE
make sample build and connect

### DIFF
--- a/_examples/helloworld/consumer/main.go
+++ b/_examples/helloworld/consumer/main.go
@@ -22,13 +22,15 @@ func main() {
 	q, err := getQueue(ns, queueName)
 	if err != nil {
 		fmt.Printf("failed to build a new queue named %q\n", queueName)
+		fmt.Printf("error %s\n", err)
 		os.Exit(1)
 	}
 
 	exit := make(chan struct{})
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
+	fmt.Println("Setting up listener...")
 	listenHandle, err := q.Receive(ctx, func(ctx context.Context, message *servicebus.Message) servicebus.DispositionAction {
 		text := string(message.Data)
 		if text == "exit\n" {
@@ -60,7 +62,7 @@ func main() {
 }
 
 func getQueue(ns *servicebus.Namespace, queueName string) (*servicebus.Queue, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
 	qm := ns.NewQueueManager()

--- a/_examples/helloworld/producer/main.go
+++ b/_examples/helloworld/producer/main.go
@@ -30,7 +30,7 @@ func main() {
 	for {
 		fmt.Print("Enter text: ")
 		text, _ := reader.ReadString('\n')
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		q.Send(ctx, servicebus.NewMessageFromString(text))
 		if text == "exit\n" {
 			break
@@ -40,8 +40,6 @@ func main() {
 }
 
 func getQueue(ns *servicebus.Namespace, queueName string) (*servicebus.Queue, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	q, err := ns.NewQueue(queueName)
 	return q, err
 }


### PR DESCRIPTION
When I ran `make` on the sample it failed to build with:

```
 make
# command-line-arguments
producer/main.go:43:2: ctx declared and not used
Makefile:11: recipe for target 'build' failed
make: *** [build] Error 2
```

After fixing the build error I was not able to connect to the queue and recieved this error message:

```
./bin/consumer
failed to build a new queue named "helloworld"
error Get https://k8custom.servicebus.windows.net/helloworld?api-version=2017-04: context deadline exceeded
```

I removed the unused context timeout and increased the other timeouts and was able to run the sample successfully.