### PR TITLE
Removing context from Subscription and Topic constructors.

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -116,8 +116,8 @@ func (t *Topic) NewSubscriptionManager() *SubscriptionManager {
 }
 
 // NewSubscriptionManager creates a new SubscriptionManger for a Service Bus Namespace
-func (ns *Namespace) NewSubscriptionManager(ctx context.Context, topicName string) (*SubscriptionManager, error) {
-	t, err := ns.NewTopic(ctx, topicName)
+func (ns *Namespace) NewSubscriptionManager(topicName string) (*SubscriptionManager, error) {
+	t, err := ns.NewTopic(topicName)
 	if err != nil {
 		return nil, err
 	}
@@ -280,10 +280,7 @@ func SubscriptionWithReceiveAndDelete() SubscriptionOption {
 }
 
 // NewSubscription creates a new Topic Subscription client
-func (t *Topic) NewSubscription(ctx context.Context, name string, opts ...SubscriptionOption) (*Subscription, error) {
-	span, ctx := t.startSpanFromContext(ctx, "sb.Topic.NewSubscription")
-	defer span.Finish()
-
+func (t *Topic) NewSubscription(name string, opts ...SubscriptionOption) (*Subscription, error) {
 	sub := &Subscription{
 		entity: &entity{
 			namespace: t.namespace,
@@ -292,9 +289,8 @@ func (t *Topic) NewSubscription(ctx context.Context, name string, opts ...Subscr
 		Topic: t,
 	}
 
-	for _, opt := range opts {
-		if err := opt(sub); err != nil {
-			log.For(ctx).Error(err)
+	for i := range opts {
+		if err := opts[i](sub); err != nil {
 			return nil, err
 		}
 	}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -104,7 +104,7 @@ func (suite *serviceBusSuite) TestSubscriptionManagementWrites() {
 	defer outerCancel()
 	topicName := suite.RandomName("gosb", 6)
 	cleanupTopic := makeTopic(outerCtx, suite.T(), ns, topicName)
-	topic, err := ns.NewTopic(outerCtx, topicName)
+	topic, err := ns.NewTopic(topicName)
 	if suite.NoError(err) {
 		sm := topic.NewSubscriptionManager()
 		for name, testFunc := range tests {
@@ -160,7 +160,7 @@ func (suite *serviceBusSuite) TestSubscriptionManagement() {
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 			defer cancel()
 			cleanupTopic := makeTopic(ctx, t, ns, topicName)
-			topic, err := ns.NewTopic(ctx, topicName)
+			topic, err := ns.NewTopic(topicName)
 			if suite.NoError(err) {
 				sm := topic.NewSubscriptionManager()
 				if suite.NoError(err) {
@@ -250,11 +250,11 @@ func (suite *serviceBusSuite) TestSubscriptionClient() {
 			defer cancel()
 
 			topicCleanup := makeTopic(ctx, t, ns, topicName)
-			topic, err := ns.NewTopic(ctx, topicName)
+			topic, err := ns.NewTopic(topicName)
 			if suite.NoError(err) {
 				subName := suite.randEntityName()
 				subCleanup := makeSubscription(ctx, t, topic, subName)
-				subscription, err := topic.NewSubscription(ctx, subName)
+				subscription, err := topic.NewSubscription(subName)
 
 				if suite.NoError(err) {
 					defer subCleanup()

--- a/topic.go
+++ b/topic.go
@@ -267,10 +267,7 @@ func topicEntryToEntity(entry *topicEntry) *TopicEntity {
 }
 
 // NewTopic creates a new Topic Sender
-func (ns *Namespace) NewTopic(ctx context.Context, name string, opts ...TopicOption) (*Topic, error) {
-	span, ctx := ns.startSpanFromContext(ctx, "sb.Namespace.NewTopic")
-	defer span.Finish()
-
+func (ns *Namespace) NewTopic(name string, opts ...TopicOption) (*Topic, error) {
 	topic := &Topic{
 		entity: &entity{
 			namespace: ns,
@@ -278,9 +275,8 @@ func (ns *Namespace) NewTopic(ctx context.Context, name string, opts ...TopicOpt
 		},
 	}
 
-	for _, opt := range opts {
-		if err := opt(topic); err != nil {
-			log.For(ctx).Error(err)
+	for i := range opts {
+		if err := opts[i](topic); err != nil {
 			return nil, err
 		}
 	}

--- a/topic_test.go
+++ b/topic_test.go
@@ -297,7 +297,7 @@ func (suite *serviceBusSuite) TestTopic() {
 			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 			defer cancel()
 			_ = makeTopic(ctx, t, ns, name)
-			topic, err := ns.NewTopic(ctx, name)
+			topic, err := ns.NewTopic(name)
 			if suite.NoError(err) {
 				defer func() {
 					topic.Close(ctx)


### PR DESCRIPTION
This is done to drive API consistency after #28. The reasoning is the same;
now that there is no out-of-process work to do in these constructors,
there need not be a cancellation token injected. It would also make for
some very verbose log messages.