### PR TITLE
Restore message UserProperties from amqp message

### DIFF
--- a/message.go
+++ b/message.go
@@ -319,7 +319,7 @@ func newMessage(data []byte, amqpMsg *amqp.Message) (*Message, error) {
 	}
 
 	if amqpMsg.ApplicationProperties != nil {
-		msg.UserProperties = make(map[string]interface{})
+		msg.UserProperties = make(map[string]interface{}, len(amqpMsg.ApplicationProperties))
 		for key, value := range amqpMsg.ApplicationProperties {
 			msg.UserProperties[key] = value
 		}

--- a/message.go
+++ b/message.go
@@ -318,6 +318,13 @@ func newMessage(data []byte, amqpMsg *amqp.Message) (*Message, error) {
 		msg.TTL = &amqpMsg.Header.TTL
 	}
 
+	if amqpMsg.ApplicationProperties != nil {
+		msg.UserProperties = make(map[string]interface{})
+		for key, value := range amqpMsg.ApplicationProperties {
+			msg.UserProperties[key] = value
+		}
+	}
+
 	if amqpMsg.Annotations != nil {
 		if err := mapstructure.Decode(amqpMsg.Annotations, &msg.SystemProperties); err != nil {
 			return msg, err

--- a/message_test.go
+++ b/message_test.go
@@ -101,6 +101,10 @@ func (suite *serviceBusSuite) TestMessageToAMQPMessage() {
 				suite.Equal(val, aMsg.Annotations[key], key)
 			}
 		}
+
+		for key, val := range msg.UserProperties {
+			suite.Equal(val, aMsg.ApplicationProperties[key], key)
+		}
 	}
 }
 
@@ -175,5 +179,8 @@ func (suite *serviceBusSuite) TestAMQPMessageToMessage() {
 			}
 		}
 
+		for key, val := range aMsg.ApplicationProperties {
+			suite.Equal(val, msg.UserProperties[key], key)
+		}
 	}
 }


### PR DESCRIPTION
I noticed that message.UserProperties are empty once the message is received. There's the fix.