### PR TITLE
Enable forwarding of messages

### DIFF
--- a/mgmt.go
+++ b/mgmt.go
@@ -275,6 +275,20 @@ func addSupplementalAuthorization(supplementalURI string, tp auth.TokenProvider)
 	}
 }
 
+func addDeadLetterSupplementalAuthorization(targetURI string, tp auth.TokenProvider) MiddlewareFunc {
+	return func(next RestHandler) RestHandler {
+		return func(ctx context.Context, req *http.Request) (response *http.Response, e error) {
+			signature, err := tp.GetToken(targetURI)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Add("ServiceBusDlqSupplementaryAuthorization", signature.Token)
+			return next(ctx, req)
+		}
+	}
+}
+
 // TraceReqAndResponseMiddleware will print the dump of the management request and response.
 //
 // This should only be used for debugging or educational purposes.

--- a/package_examples_test.go
+++ b/package_examples_test.go
@@ -33,10 +33,7 @@ func Example_helloWorld() {
 		return
 	}
 
-	err = q.Send(ctx, servicebus.NewMessageFromString("Hello, World!!!"))
-	if err != nil {
-		return
-	}
+	err = q.Send(ctx, servicebus.NewMessageFromString("Hello, World!!!"))ß
 	if err != nil {
 		fmt.Println("FATAL: ", err)
 		return

--- a/package_examples_test.go
+++ b/package_examples_test.go
@@ -33,7 +33,7 @@ func Example_helloWorld() {
 		return
 	}
 
-	err = q.Send(ctx, servicebus.NewMessageFromString("Hello, World!!!"))ß
+	err = q.Send(ctx, servicebus.NewMessageFromString("Hello, World!!!"))
 	if err != nil {
 		fmt.Println("FATAL: ", err)
 		return

--- a/queue.go
+++ b/queue.go
@@ -90,6 +90,7 @@ type (
 		EnablePartitioning                  *bool         `xml:"EnablePartitioning,omitempty"`
 		EnableExpress                       *bool         `xml:"EnableExpress,omitempty"`
 		CountDetails                        *CountDetails `xml:"CountDetails,omitempty"`
+		ForwardTo                           *string       `xml:"ForwardTo,omitempty"`
 	}
 
 	// QueueOption represents named options for assisting Queue message handling

--- a/queue.go
+++ b/queue.go
@@ -91,6 +91,7 @@ type (
 		EnableExpress                       *bool         `xml:"EnableExpress,omitempty"`
 		CountDetails                        *CountDetails `xml:"CountDetails,omitempty"`
 		ForwardTo                           *string       `xml:"ForwardTo,omitempty"`
+		ForwardDeadLetteredMessagesTo       *string       `xml:"ForwardDeadLetteredMessagesTo,omitempty"` // ForwardDeadLetteredMessagesTo - absolute URI of the entity to forward dead letter messages
 	}
 
 	// QueueOption represents named options for assisting Queue message handling

--- a/queue_manager.go
+++ b/queue_manager.go
@@ -181,6 +181,10 @@ func QueueEntityWithLockDuration(window *time.Duration) QueueManagementOption {
 }
 
 // QueueEntityWithAutoForward configures the queue to automatically forward messages to the specified entity path
+//
+// The ability to AutoForward to a target requires the connection have management authorization. If the connection
+// string or Azure Active Directory identity used does not have management authorization, an unauthorized error will be
+// returned on the PUT.
 func QueueEntityWithAutoForward(target Targetable) QueueManagementOption {
 	return func(q *QueueDescription) error {
 		uri := target.TargetURI()

--- a/queue_test.go
+++ b/queue_test.go
@@ -315,9 +315,11 @@ func (suite *serviceBusSuite) TestQueueManager_QueueWithAutoForward() {
 func testQueueWithAutoForward(ctx context.Context, t *testing.T, qm *QueueManager, name string) {
 	targetQueueName := "target-" + name
 	target := buildQueue(ctx, t, qm, targetQueueName)
-	defer assert.NoError(t, qm.Delete(ctx, targetQueueName))
+	defer func() {
+		assert.NoError(t, qm.Delete(ctx, targetQueueName))
+	}()
 	src := buildQueue(ctx, t, qm, name, QueueEntityWithAutoForward(target))
-	assert.Equal(t, target.EntityID(), *src.ForwardTo)
+	assert.Equal(t, target.TargetURI(), *src.ForwardTo)
 }
 
 func (suite *serviceBusSuite) TestQueueManagement() {

--- a/queue_test.go
+++ b/queue_test.go
@@ -315,6 +315,7 @@ func (suite *serviceBusSuite) TestQueueManagement() {
 		"TestQueueWithLockDuration":                     testQueueWithLockDuration,
 		"TestQueueWithAutoDeleteOnIdle":                 testQueueWithAutoDeleteOnIdle,
 		"TestQueueWithPartitioning":                     testQueueWithPartitioning,
+		"TestQueueWithAutoForward":                      testQueueWithAutoForward,
 	}
 
 	ns := suite.getNewSasInstance()
@@ -389,6 +390,12 @@ func testQueueWithLockDuration(ctx context.Context, t *testing.T, qm *QueueManag
 	window := time.Duration(3 * time.Minute)
 	q := buildQueue(ctx, t, qm, name, QueueEntityWithLockDuration(&window))
 	assert.Equal(t, "PT3M", *q.LockDuration)
+}
+
+func testQueueWithAutoForward(ctx context.Context, t *testing.T, qm *QueueManager, name string) {
+	absoluteEntityURI := "sb://foo.servicebus.windows.net/bazz"
+	q := buildQueue(ctx, t, qm, name, QueueEntityWithAutoForward(absoluteEntityURI))
+	assert.Equal(t, absoluteEntityURI, *q.ForwardTo)
 }
 
 func buildQueue(ctx context.Context, t *testing.T, qm *QueueManager, name string, opts ...QueueManagementOption) *QueueEntity {

--- a/subscription.go
+++ b/subscription.go
@@ -62,7 +62,8 @@ type (
 		UpdatedAt                                 *date.Time    `xml:"UpdatedAt,omitempty"`
 		AccessedAt                                *date.Time    `xml:"AccessedAt,omitempty"`
 		AutoDeleteOnIdle                          *string       `xml:"AutoDeleteOnIdle,omitempty"`
-		ForwardTo                                 *string       `xml:"ForwardTo,omitempty"` // ForwardTo - absolute URI of the entity to forward messages
+		ForwardTo                                 *string       `xml:"ForwardTo,omitempty"`                     // ForwardTo - absolute URI of the entity to forward messages
+		ForwardDeadLetteredMessagesTo             *string       `xml:"ForwardDeadLetteredMessagesTo,omitempty"` // ForwardDeadLetteredMessagesTo - absolute URI of the entity to forward dead letter messages
 	}
 
 	// SubscriptionOption configures the Subscription Azure Service Bus client

--- a/subscription.go
+++ b/subscription.go
@@ -62,6 +62,7 @@ type (
 		UpdatedAt                                 *date.Time    `xml:"UpdatedAt,omitempty"`
 		AccessedAt                                *date.Time    `xml:"AccessedAt,omitempty"`
 		AutoDeleteOnIdle                          *string       `xml:"AutoDeleteOnIdle,omitempty"`
+		ForwardTo                                 *string       `xml:"ForwardTo,omitempty"` // ForwardTo - absolute URI of the entity to forward messages
 	}
 
 	// SubscriptionOption configures the Subscription Azure Service Bus client

--- a/subscription_manager.go
+++ b/subscription_manager.go
@@ -221,6 +221,10 @@ func SubscriptionWithBatchedOperations() SubscriptionManagementOption {
 }
 
 // SubscriptionWithAutoForward configures the queue to automatically forward messages to the specified entity path
+//
+// The ability to AutoForward to a target requires the connection have management authorization. If the connection
+// string or Azure Active Directory identity used does not have management authorization, an unauthorized error will be
+// returned on the PUT.
 func SubscriptionWithAutoForward(target Targetable) SubscriptionManagementOption {
 	return func(s *SubscriptionDescription) error {
 		uri := target.TargetURI()

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -142,6 +142,25 @@ func (suite *serviceBusSuite) cleanupSubscription(topic *Topic, subscriptionName
 	}
 }
 
+func (suite *serviceBusSuite) TestSubscriptionManager_SubscriptionWithAutoForward() {
+	tests := map[string]func(context.Context, *testing.T, *SubscriptionManager, string, string){
+		"TestSubscriptionWithAutoForward": testSubscriptionWithAutoForward,
+	}
+
+	suite.testSubscriptionManager(tests)
+}
+
+func testSubscriptionWithAutoForward(ctx context.Context, t *testing.T, sm *SubscriptionManager, _, subName string) {
+	targetName := "target-" + subName
+	target := buildSubscription(ctx, t, sm, targetName)
+	defer func() {
+		assert.NoError(t, sm.Delete(ctx, targetName))
+	}()
+
+	src := buildSubscription(ctx, t, sm, subName, SubscriptionWithAutoForward(target))
+	assert.Equal(t, target.TargetURI(), *src.ForwardTo)
+}
+
 func (suite *serviceBusSuite) TestSubscriptionManagement() {
 	tests := map[string]func(context.Context, *testing.T, *SubscriptionManager, string, string){
 		"TestSubscriptionDefaultSettings":                      testDefaultSubscription,
@@ -153,33 +172,7 @@ func (suite *serviceBusSuite) TestSubscriptionManagement() {
 		"TestSubscriptionWithBatchedOperations":                testSubscriptionWithBatchedOperations,
 	}
 
-	ns := suite.getNewSasInstance()
-	for name, testFunc := range tests {
-		topicName := suite.randEntityName()
-		subName := suite.randEntityName()
-
-		setupTestTeardown := func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-			defer cancel()
-			cleanupTopic := makeTopic(ctx, t, ns, topicName)
-			topic, err := ns.NewTopic(topicName)
-			if suite.NoError(err) {
-				sm := topic.NewSubscriptionManager()
-				if suite.NoError(err) {
-					defer func(sName string) {
-						ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-						defer cancel()
-						if !suite.NoError(sm.Delete(ctx, sName)) {
-							suite.Fail(err.Error())
-						}
-					}(subName)
-					testFunc(ctx, t, sm, topicName, subName)
-				}
-			}
-			defer cleanupTopic()
-		}
-		suite.T().Run(name, setupTestTeardown)
-	}
+	suite.testSubscriptionManager(tests)
 }
 
 func testDefaultSubscription(ctx context.Context, t *testing.T, sm *SubscriptionManager, _, name string) {
@@ -236,6 +229,36 @@ func buildSubscription(ctx context.Context, t *testing.T, sm *SubscriptionManage
 		assert.FailNow(t, fmt.Sprintf("%v", err))
 	}
 	return s
+}
+
+func (suite *serviceBusSuite) testSubscriptionManager(tests map[string]func(context.Context, *testing.T, *SubscriptionManager, string, string)) {
+	ns := suite.getNewSasInstance()
+	for name, testFunc := range tests {
+		topicName := suite.randEntityName()
+		subName := suite.randEntityName()
+
+		setupTestTeardown := func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+			defer cancel()
+			cleanupTopic := makeTopic(ctx, t, ns, topicName)
+			topic, err := ns.NewTopic(topicName)
+			if suite.NoError(err) {
+				sm := topic.NewSubscriptionManager()
+				if suite.NoError(err) {
+					defer func(sName string) {
+						ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+						defer cancel()
+						if !suite.NoError(sm.Delete(ctx, sName)) {
+							suite.Fail(err.Error())
+						}
+					}(subName)
+					testFunc(ctx, t, sm, topicName, subName)
+				}
+			}
+			defer cleanupTopic()
+		}
+		suite.T().Run(name, setupTestTeardown)
+	}
 }
 
 func (suite *serviceBusSuite) TestSubscription_WithReceiveAndDelete() {


### PR DESCRIPTION
- add middleware pipeline to the entity manager
  - there some refactoring of the entity managers needed. so much duplicated code...
- add supplemental auth for both dead letter and forward to targets
- introduce the targetable interface for any entity that can be a target of forwarding
- add management options for building queues and subscriptions that forward

fixes #42 