### PR TITLE
Message batching with an iterator

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,0 +1,156 @@
+package servicebus
+
+import (
+	"github.com/Azure/azure-amqp-common-go/uuid"
+	"pack.ag/amqp"
+)
+
+type (
+	// MessageBatchIterator provides an easy way to iterate over a slice of messages to reliably create batches
+	MessageBatchIterator struct {
+		Messages []*Message
+		Cursor   int
+		MaxSize  MaxMessageSizeInBytes
+	}
+
+	// MessageBatch represents a batch of messages to send to Service Bus in a single message
+	MessageBatch struct {
+		marshaledMessages [][]byte
+		SessionID         *string
+		ID                *string
+		MaxSize           MaxMessageSizeInBytes
+		size              int
+	}
+
+	// MaxMessageSizeInBytes is the max number of bytes allowed by Azure Service Bus
+	MaxMessageSizeInBytes int
+)
+
+const (
+	// StandardMaxMessageSizeInBytes is the maximum number of bytes in a message for the Standard tier
+	StandardMaxMessageSizeInBytes MaxMessageSizeInBytes = 256000
+	// PremiumMaxMessageSizeInBytes is the maximum number of bytes in a message for the Premium tier
+	PremiumMaxMessageSizeInBytes MaxMessageSizeInBytes = 1000000
+
+	batchMessageFormat uint32 = 0x80013700
+
+	batchMessageWrapperSize = 100
+)
+
+// NewMessageBatchIterator wraps a slice of Message pointers to allow it to be made into a MessageIterator.
+func NewMessageBatchIterator(maxBatchSize MaxMessageSizeInBytes, msgs ...*Message) *MessageBatchIterator {
+	return &MessageBatchIterator{
+		Messages: msgs,
+		MaxSize:  maxBatchSize,
+	}
+}
+
+// Done communicates whether there are more messages remaining to be iterated over.
+func (mbi *MessageBatchIterator) Done() bool {
+	return len(mbi.Messages) == mbi.Cursor
+}
+
+// Next fetches the batch of messages in the message slice at a position one larger than the last one accessed.
+func (mbi *MessageBatchIterator) Next() (*MessageBatch, error) {
+	if mbi.Done() {
+		return nil, ErrNoMessages{}
+	}
+
+	mb, err := NewMessageBatch(mbi.MaxSize)
+	if err != nil {
+		return nil, err
+	}
+
+	for mbi.Cursor < len(mbi.Messages) {
+		ok, err := mb.Add(mbi.Messages[mbi.Cursor])
+		if err != nil {
+			return nil, err
+		}
+
+		mbi.Cursor++
+		if !ok {
+			return mb, nil
+		}
+	}
+	return mb, nil
+}
+
+// NewMessageBatch builds a new message batch with a default standard max message size
+func NewMessageBatch(maxSize MaxMessageSizeInBytes) (*MessageBatch, error) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+
+	return &MessageBatch{
+		MaxSize: maxSize,
+		ID:      ptrString(id.String()),
+	}, err
+}
+
+// Add adds a message to the batch if the message will not exceed the max size of the batch
+func (mb *MessageBatch) Add(m *Message) (bool, error) {
+	msg, err := m.toMsg()
+	if err != nil {
+		return false, err
+	}
+	msg.Properties.MessageID = mb.ID
+	msg.Format = batchMessageFormat
+
+	bin, err := msg.MarshalBinary()
+	if err != nil {
+		return false, err
+	}
+
+	if mb.Size()+len(bin) > int(mb.MaxSize) {
+		return false, nil
+	}
+
+	mb.size += len(bin)
+	mb.marshaledMessages = append(mb.marshaledMessages, bin)
+	return true, nil
+}
+
+// Clear will zero out the batch size and clear the buffered messages
+func (mb *MessageBatch) Clear() {
+	mb.marshaledMessages = [][]byte{}
+	mb.size = 0
+}
+
+// Size is the number of bytes in the message batch
+func (mb *MessageBatch) Size() int {
+	// calculated data size + batch message wrapper + data wrapper portions of the message
+	return mb.size + batchMessageWrapperSize + (len(mb.marshaledMessages) * 5)
+}
+
+// ToMessage builds a Azure Service Bus message from the buffered batch messages
+func (mb *MessageBatch) ToMessage() (*Message, error) {
+	batchMessage := mb.amqpBatchMessage()
+
+	batchMessage.Data = make([][]byte, len(mb.marshaledMessages))
+	for idx, bytes := range mb.marshaledMessages {
+		batchMessage.Data[idx] = bytes
+	}
+
+	return messageFromAMQPMessage(batchMessage)
+}
+
+func (mb *MessageBatch) toMsg() (*amqp.Message, error) {
+	batchMessage := mb.amqpBatchMessage()
+
+	batchMessage.Data = make([][]byte, len(mb.marshaledMessages))
+	for idx, bytes := range mb.marshaledMessages {
+		batchMessage.Data[idx] = bytes
+	}
+	return batchMessage, nil
+}
+
+func (mb *MessageBatch) amqpBatchMessage() *amqp.Message {
+	return &amqp.Message{
+		Data:   make([][]byte, len(mb.marshaledMessages)),
+		Format: batchMessageFormat,
+		Properties: &amqp.MessageProperties{
+			MessageID: mb.ID,
+		},
+	}
+}

--- a/batch.go
+++ b/batch.go
@@ -1,6 +1,7 @@
 package servicebus
 
 import (
+	"github.com/Azure/azure-amqp-common-go/uuid"
 	"pack.ag/amqp"
 )
 
@@ -76,10 +77,10 @@ func (mbi *MessageBatchIterator) Next(messageID string, opts *BatchOptions) (*Me
 			return nil, err
 		}
 
-		mbi.Cursor++
 		if !ok {
 			return mb, nil
 		}
+		mbi.Cursor++
 	}
 	return mb, nil
 }
@@ -108,7 +109,14 @@ func (mb *MessageBatch) Add(m *Message) (bool, error) {
 		return false, err
 	}
 
-	msg.Properties.MessageID = mb.ID
+	if msg.Properties.MessageID == nil || msg.Properties.MessageID == "" {
+		uid, err := uuid.NewV4()
+		if err != nil {
+			return false, err
+		}
+		msg.Properties.MessageID = uid.String()
+	}
+
 	if mb.SessionID != nil {
 		msg.Properties.GroupID = *mb.SessionID
 	}

--- a/batch_test.go
+++ b/batch_test.go
@@ -18,7 +18,7 @@ func TestMessageBatch_AddOneMessage(t *testing.T) {
 	msg := NewMessageFromString("Foo")
 	ok, err := mb.Add(msg)
 	assert.True(t, ok)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 }
 
 func TestMessageBatch_AddManyMessages(t *testing.T) {
@@ -29,7 +29,7 @@ func TestMessageBatch_AddManyMessages(t *testing.T) {
 	msg := NewMessageFromString("Foo")
 	ok, err := mb.Add(msg)
 	assert.True(t, ok)
-	assert.NoError(t,err)
+	assert.NoError(t, err)
 	msgSize := mb.Size() - wrapperSize
 
 	limit := ((int(mb.MaxSize) - 100) / msgSize) - 1

--- a/batch_test.go
+++ b/batch_test.go
@@ -7,14 +7,12 @@ import (
 )
 
 func TestNewMessageBatch(t *testing.T) {
-	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
-	assert.NoError(t, err)
+	mb := NewMessageBatch(StandardMaxMessageSizeInBytes, "messageID", &BatchOptions{})
 	assert.Equal(t, StandardMaxMessageSizeInBytes, mb.MaxSize)
 }
 
 func TestMessageBatch_AddOneMessage(t *testing.T) {
-	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
-	assert.NoError(t, err)
+	mb := NewMessageBatch(StandardMaxMessageSizeInBytes, "messageID", &BatchOptions{})
 	msg := NewMessageFromString("Foo")
 	ok, err := mb.Add(msg)
 	assert.True(t, ok)
@@ -22,9 +20,10 @@ func TestMessageBatch_AddOneMessage(t *testing.T) {
 }
 
 func TestMessageBatch_AddManyMessages(t *testing.T) {
-	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
-	assert.NoError(t, err)
-
+	bOpts := &BatchOptions{
+		SessionID: ptrString("foobarbazzbuzz"),
+	}
+	mb := NewMessageBatch(StandardMaxMessageSizeInBytes, "messageID", bOpts)
 	wrapperSize := mb.Size()
 	msg := NewMessageFromString("Foo")
 	ok, err := mb.Add(msg)
@@ -45,13 +44,11 @@ func TestMessageBatch_AddManyMessages(t *testing.T) {
 }
 
 func TestMessageBatch_Clear(t *testing.T) {
-	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
-	assert.NoError(t, err)
-
+	mb := NewMessageBatch(StandardMaxMessageSizeInBytes, "messageID", &BatchOptions{})
 	ok, err := mb.Add(NewMessageFromString("foo"))
 	assert.True(t, ok)
 	assert.NoError(t, err)
-	assert.Equal(t, 139, mb.Size())
+	assert.Equal(t, 148, mb.Size())
 
 	mb.Clear()
 	assert.Equal(t, 100, mb.Size())

--- a/batch_test.go
+++ b/batch_test.go
@@ -1,0 +1,58 @@
+package servicebus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMessageBatch(t *testing.T) {
+	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, StandardMaxMessageSizeInBytes, mb.MaxSize)
+}
+
+func TestMessageBatch_AddOneMessage(t *testing.T) {
+	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
+	assert.NoError(t, err)
+	msg := NewMessageFromString("Foo")
+	ok, err := mb.Add(msg)
+	assert.True(t, ok)
+	assert.NoError(t,err)
+}
+
+func TestMessageBatch_AddManyMessages(t *testing.T) {
+	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
+	assert.NoError(t, err)
+
+	wrapperSize := mb.Size()
+	msg := NewMessageFromString("Foo")
+	ok, err := mb.Add(msg)
+	assert.True(t, ok)
+	assert.NoError(t,err)
+	msgSize := mb.Size() - wrapperSize
+
+	limit := ((int(mb.MaxSize) - 100) / msgSize) - 1
+	for i := 0; i < limit; i++ {
+		ok, err := mb.Add(msg)
+		assert.True(t, ok)
+		assert.NoError(t, err)
+	}
+
+	ok, err = mb.Add(msg)
+	assert.False(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestMessageBatch_Clear(t *testing.T) {
+	mb, err := NewMessageBatch(StandardMaxMessageSizeInBytes)
+	assert.NoError(t, err)
+
+	ok, err := mb.Add(NewMessageFromString("foo"))
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, 139, mb.Size())
+
+	mb.Clear()
+	assert.Equal(t, 100, mb.Size())
+}

--- a/batch_test.go
+++ b/batch_test.go
@@ -48,7 +48,7 @@ func TestMessageBatch_Clear(t *testing.T) {
 	ok, err := mb.Add(NewMessageFromString("foo"))
 	assert.True(t, ok)
 	assert.NoError(t, err)
-	assert.Equal(t, 148, mb.Size())
+	assert.Equal(t, 175, mb.Size())
 
 	mb.Clear()
 	assert.Equal(t, 100, mb.Size())

--- a/batching_example_test.go
+++ b/batching_example_test.go
@@ -1,0 +1,75 @@
+package servicebus_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-service-bus-go"
+)
+
+func Example_batchingMessages() {
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
+	defer cancel()
+
+	connStr := os.Getenv("SERVICEBUS_CONNECTION_STRING")
+	if connStr == "" {
+		fmt.Println("FATAL: expected environment variable SERVICEBUS_CONNECTION_STRING not set")
+		return
+	}
+
+	// Create a client to communicate with a Service Bus Namespace.
+	ns, err := servicebus.NewNamespace(servicebus.NamespaceWithConnectionString(connStr))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	qm := ns.NewQueueManager()
+	qe, err := ensureQueue(ctx, qm, "MessageBatchingExample")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	q, err := ns.NewQueue(qe.Name)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer func() {
+		_ = q.Close(ctx)
+	}()
+
+	msgs := make([]*servicebus.Message, 10)
+	for i := 0; i < 10; i++ {
+		msgs[i] = servicebus.NewMessageFromString(fmt.Sprintf("foo %d", i))
+	}
+
+	batcher := servicebus.NewMessageBatchIterator(servicebus.StandardMaxMessageSizeInBytes, msgs...)
+	if err := q.SendBatch(ctx, batcher); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	for i := 0; i < 10; i++ {
+		err := q.ReceiveOne(ctx, MessagePrinter{})
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+
+	// Output:
+	// foo 0
+	// foo 1
+	// foo 2
+	// foo 3
+	// foo 4
+	// foo 5
+	// foo 6
+	// foo 7
+	// foo 8
+	// foo 9
+}

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -71,7 +71,9 @@ func init() {
 
 // SetupSuite prepares the test suite and provisions a standard Service Bus Namespace
 func (suite *BaseSuite) SetupSuite() {
-	godotenv.Load()
+	if err := godotenv.Load(); err != nil {
+		suite.T().Log(err)
+	}
 
 	setFromEnv := func(key string, target *string) {
 		v := os.Getenv(key)

--- a/iterator.go
+++ b/iterator.go
@@ -51,7 +51,7 @@ func (ms MessageSliceIterator) Done() bool {
 	return ms.Cursor >= len(ms.Target)
 }
 
-// Next fetches the Message in the slice at a position one larger than the last one accessed.s
+// Next fetches the Message in the slice at a position one larger than the last one accessed.
 func (ms *MessageSliceIterator) Next(_ context.Context) (*Message, error) {
 	if ms.Done() {
 		return nil, ErrNoMessages{}

--- a/lockrenewal_test.go
+++ b/lockrenewal_test.go
@@ -32,7 +32,7 @@ func (suite *serviceBusSuite) TestQueueSendReceiveWithLock() {
 			suite.NoError(q.Close(ctx))
 			if !t.Failed() {
 				// If there are message on the queue this would mean that a lock wasn't held and the message was requeued.
-				checkZeroQueueMessages(ctx, t, ns, queueName)
+				assertZeroQueueMessages(ctx, t, ns, queueName)
 			}
 		}
 		suite.T().Run(name, setupTestTeardown)

--- a/message.go
+++ b/message.go
@@ -405,7 +405,6 @@ func (m *Message) toMsg() (*amqp.Message, error) {
 	amqpMsg.Properties.ReplyTo = m.ReplyTo
 	amqpMsg.Properties.ReplyToGroupID = m.ReplyToGroupID
 
-
 	if m.SystemProperties != nil {
 		sysPropMap, err := encodeStructureToMap(m.SystemProperties)
 		if err != nil {

--- a/message.go
+++ b/message.go
@@ -399,6 +399,13 @@ func (m *Message) toMsg() (*amqp.Message, error) {
 	amqpMsg.Properties.ReplyTo = m.ReplyTo
 	amqpMsg.Properties.ReplyToGroupID = m.ReplyToGroupID
 
+	if len(m.UserProperties) > 0 {
+		amqpMsg.ApplicationProperties = make(map[string]interface{})
+		for key, value := range m.UserProperties {
+			amqpMsg.ApplicationProperties[key] = value
+		}
+	}
+
 	if m.SystemProperties != nil {
 		sysPropMap, err := encodeStructureToMap(m.SystemProperties)
 		if err != nil {

--- a/message.go
+++ b/message.go
@@ -55,6 +55,7 @@ type (
 		LockToken        *uuid.UUID
 		SystemProperties *SystemProperties
 		UserProperties   map[string]interface{}
+		Format           uint32
 		message          *amqp.Message
 		ec               entityConnector // if an entity connector is present, a message should send disposition via mgmt
 	}
@@ -366,11 +367,24 @@ func sendMgmtDisposition(ctx context.Context, m *Message, state disposition) err
 	return nil
 }
 
-func (m *Message) toMsg() (*amqp.Message, error) {
+func (m *Message) toMsgCore() *amqp.Message {
 	amqpMsg := m.message
 	if amqpMsg == nil {
 		amqpMsg = amqp.NewMessage(m.Data)
 	}
+
+	if m.TTL != nil {
+		if amqpMsg.Header == nil {
+			amqpMsg.Header = new(amqp.MessageHeader)
+		}
+		amqpMsg.Header.TTL = *m.TTL
+	}
+
+	return amqpMsg
+}
+
+func (m *Message) toMsg() (*amqp.Message, error) {
+	amqpMsg := m.toMsgCore()
 
 	amqpMsg.Properties = &amqp.MessageProperties{
 		MessageID: m.ID,
@@ -391,12 +405,6 @@ func (m *Message) toMsg() (*amqp.Message, error) {
 	amqpMsg.Properties.ReplyTo = m.ReplyTo
 	amqpMsg.Properties.ReplyToGroupID = m.ReplyToGroupID
 
-	if len(m.UserProperties) > 0 {
-		amqpMsg.ApplicationProperties = make(map[string]interface{})
-		for key, value := range m.UserProperties {
-			amqpMsg.ApplicationProperties[key] = value
-		}
-	}
 
 	if m.SystemProperties != nil {
 		sysPropMap, err := encodeStructureToMap(m.SystemProperties)
@@ -411,13 +419,6 @@ func (m *Message) toMsg() (*amqp.Message, error) {
 			amqpMsg.DeliveryAnnotations = make(amqp.Annotations)
 		}
 		amqpMsg.DeliveryAnnotations[lockTokenName] = *m.LockToken
-	}
-
-	if m.TTL != nil {
-		if amqpMsg.Header == nil {
-			amqpMsg.Header = new(amqp.MessageHeader)
-		}
-		amqpMsg.Header.TTL = *m.TTL
 	}
 
 	return amqpMsg, nil
@@ -459,8 +460,10 @@ func newMessage(data []byte, amqpMsg *amqp.Message) (*Message, error) {
 		msg.To = amqpMsg.Properties.To
 		msg.ReplyTo = amqpMsg.Properties.ReplyTo
 		msg.ReplyToGroupID = amqpMsg.Properties.ReplyToGroupID
-		msg.DeliveryCount = amqpMsg.Header.DeliveryCount + 1
-		msg.TTL = &amqpMsg.Header.TTL
+		if amqpMsg.Header != nil {
+			msg.DeliveryCount = amqpMsg.Header.DeliveryCount + 1
+			msg.TTL = &amqpMsg.Header.TTL
+		}
 	}
 
 	if amqpMsg.ApplicationProperties != nil {
@@ -491,6 +494,7 @@ func newMessage(data []byte, amqpMsg *amqp.Message) (*Message, error) {
 		}
 	}
 
+	msg.Format = amqpMsg.Format
 	return msg, nil
 }
 

--- a/message.go
+++ b/message.go
@@ -367,7 +367,7 @@ func sendMgmtDisposition(ctx context.Context, m *Message, state disposition) err
 	return nil
 }
 
-func (m *Message) toMsgCore() *amqp.Message {
+func (m *Message) toMsg() (*amqp.Message, error) {
 	amqpMsg := m.message
 	if amqpMsg == nil {
 		amqpMsg = amqp.NewMessage(m.Data)
@@ -379,12 +379,6 @@ func (m *Message) toMsgCore() *amqp.Message {
 		}
 		amqpMsg.Header.TTL = *m.TTL
 	}
-
-	return amqpMsg
-}
-
-func (m *Message) toMsg() (*amqp.Message, error) {
-	amqpMsg := m.toMsgCore()
 
 	amqpMsg.Properties = &amqp.MessageProperties{
 		MessageID: m.ID,

--- a/queue.go
+++ b/queue.go
@@ -179,8 +179,9 @@ func (q *Queue) Send(ctx context.Context, msg *Message) error {
 	return q.sender.Send(ctx, msg)
 }
 
+// SendBatch sends a batch of messages to the Queue
 func (q *Queue) SendBatch(ctx context.Context, batch *MessageBatch) error {
-	span, ctx := q.startSpanFromContext(ctx, "sb.Queue.Send")
+	span, ctx := q.startSpanFromContext(ctx, "sb.Queue.SendBatch")
 	defer span.Finish()
 
 	err := q.ensureSender(ctx)

--- a/queue_test.go
+++ b/queue_test.go
@@ -671,10 +671,11 @@ func testQueueSendAndReceive(ctx context.Context, t *testing.T, q *Queue) {
 func (suite *serviceBusSuite) TestIssue73QueueClient() {
 	tests := map[string]func(context.Context, *testing.T, *Queue){
 		"SimpleSend200_NoZeroCheck": func(ctx context.Context, t *testing.T, queue *Queue) {
-			for i := 0; i < 50; i++ {
+			const count = 50
+			for i := 0; i < count; i++ {
 				testQueueSend(ctx, t, queue)
 			}
-			assertMessageCount(ctx, t, queue.namespace, queue.Name, 200)
+			assertMessageCount(ctx, t, queue.namespace, queue.Name, count)
 		},
 	}
 	window := time.Duration(20 * time.Second)

--- a/queue_test.go
+++ b/queue_test.go
@@ -671,7 +671,7 @@ func testQueueSendAndReceive(ctx context.Context, t *testing.T, q *Queue) {
 func (suite *serviceBusSuite) TestIssue73QueueClient() {
 	tests := map[string]func(context.Context, *testing.T, *Queue){
 		"SimpleSend200_NoZeroCheck": func(ctx context.Context, t *testing.T, queue *Queue) {
-			for i := 0; i < 200; i++ {
+			for i := 0; i < 50; i++ {
 				testQueueSend(ctx, t, queue)
 			}
 			assertMessageCount(ctx, t, queue.namespace, queue.Name, 200)

--- a/queue_test.go
+++ b/queue_test.go
@@ -539,13 +539,8 @@ func testSendBatch(ctx context.Context, t *testing.T, q *Queue) {
 		messages[i] = NewMessageFromString(fmt.Sprintf("hello %s!", rmsg))
 	}
 
-	mbi := NewMessageBatchIterator(StandardMaxMessageSizeInBytes, messages...)
-	for !mbi.Done() {
-		batch, err := mbi.Next()
-		assert.NoError(t, err)
-		assert.NoError(t, q.SendBatch(ctx, batch))
-	}
-
+	iterator := NewMessageBatchIterator(StandardMaxMessageSizeInBytes, messages...)
+	assert.NoError(t, q.SendBatch(ctx, iterator))
 	assertMessageCount(ctx, t, q.namespace, q.Name, 5000)
 }
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -543,7 +543,6 @@ func testSendBatch(ctx context.Context, t *testing.T, q *Queue) {
 	for !mbi.Done() {
 		batch, err := mbi.Next()
 		assert.NoError(t, err)
-		fmt.Println(mbi.Cursor)
 		assert.NoError(t, q.SendBatch(ctx, batch))
 	}
 
@@ -745,7 +744,7 @@ func (suite *serviceBusSuite) queueMessageTest(
 	for name, testFunc := range tests {
 		setupTestTeardown := func(t *testing.T) {
 			queueName := suite.randEntityName()
-			ctx, cancel := context.WithTimeout(context.Background(), 15 * time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			cleanup := makeQueue(ctx, t, ns, queueName, mgmtOptions...)
 			q, err := ns.NewQueue(queueName, queueOpts...)

--- a/queue_test.go
+++ b/queue_test.go
@@ -532,6 +532,17 @@ func testDeferMessage(ctx context.Context, t *testing.T, queue *Queue) {
 	assert.NoError(t, err)
 }
 
+func (suite *serviceBusSuite) TestQueueWithoutDuplicateDetection() {
+	tests := map[string]func(context.Context, *testing.T, *Queue){
+		"SendBatch_NoZeroCheck":  testSendBatch,
+	}
+
+	mgmtOpts := []QueueManagementOption{
+		QueueEntityWithPartitioning(),
+	}
+	suite.queueMessageTestWithMgmtOptions(tests, mgmtOpts...)
+}
+
 func testSendBatch(ctx context.Context, t *testing.T, q *Queue) {
 	messages := make([]*Message, 5000)
 	for i := 0; i < 5000; i++ {

--- a/queue_test.go
+++ b/queue_test.go
@@ -534,7 +534,7 @@ func testDeferMessage(ctx context.Context, t *testing.T, queue *Queue) {
 
 func (suite *serviceBusSuite) TestQueueWithoutDuplicateDetection() {
 	tests := map[string]func(context.Context, *testing.T, *Queue){
-		"SendBatch_NoZeroCheck":  testSendBatch,
+		"SendBatch_NoZeroCheck": testSendBatch,
 	}
 
 	mgmtOpts := []QueueManagementOption{

--- a/queue_test.go
+++ b/queue_test.go
@@ -442,7 +442,6 @@ func (suite *serviceBusSuite) TestQueueClient() {
 		"MessageProperties":      testMessageProperties,
 		"Retry":                  testRequeueOnFail,
 		"Defer":                  testDeferMessage,
-		"SendBatch_NoZeroCheck":  testSendBatch,
 	}
 
 	window := time.Duration(30 * time.Second)

--- a/receiver.go
+++ b/receiver.go
@@ -24,6 +24,7 @@ package servicebus
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Azure/azure-amqp-common-go"
@@ -202,6 +203,7 @@ func (r *Receiver) handleMessages(ctx context.Context, messages chan *amqp.Messa
 
 func (r *Receiver) handleMessage(ctx context.Context, msg *amqp.Message, handler Handler) {
 	const optName = "sb.Receiver.handleMessage"
+
 	event, err := messageFromAMQPMessage(msg)
 	if err != nil {
 		_, ctx := r.startConsumerSpanFromContext(ctx, optName)

--- a/receiver.go
+++ b/receiver.go
@@ -24,7 +24,6 @@ package servicebus
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/Azure/azure-amqp-common-go"

--- a/sender.go
+++ b/sender.go
@@ -24,7 +24,6 @@ package servicebus
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 

--- a/sender.go
+++ b/sender.go
@@ -162,6 +162,7 @@ func (s *Sender) trySend(ctx context.Context, evt eventer) error {
 
 	msg, err := evt.toMsg()
 	if err != nil {
+		log.For(ctx).Error(err)
 		return err
 	}
 
@@ -172,6 +173,9 @@ func (s *Sender) trySend(ctx context.Context, evt eventer) error {
 	for {
 		select {
 		case <-ctx.Done():
+			if ctx.Err() != nil {
+				log.For(ctx).Error(err)
+			}
 			return ctx.Err()
 		default:
 			// try as long as the context is not dead
@@ -180,8 +184,6 @@ func (s *Sender) trySend(ctx context.Context, evt eventer) error {
 				// successful send
 				return err
 			}
-
-			fmt.Println("trying but got err: ", err)
 
 			switch err.(type) {
 			case *amqp.Error, *amqp.DetachError:
@@ -194,6 +196,7 @@ func (s *Sender) trySend(ctx context.Context, evt eventer) error {
 				}
 				log.For(ctx).Debug("recovered connection")
 			default:
+				log.For(ctx).Error(err)
 				return err
 			}
 		}


### PR DESCRIPTION
Implement message batching for Queues and Topics.

``` go
	messages := make([]*Message, 5000)
	for i := 0; i < 5000; i++ {
		rmsg := test.RandomString("foo", 10)
		messages[i] = servicebus.NewMessageFromString(fmt.Sprintf("hello %s!", rmsg))
	}
	
	iterator := NewMessageBatchIterator(servicebus.StandardMaxMessageSizeInBytes, messages...)
	if err != q.SendBatch(ctx, iterator); err != nil {
                // handle error
        }
```

resolves #24