### PR TITLE
fix sender disposition mismatch

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -239,7 +239,7 @@ func (s *Sender) newSessionAndLink(ctx context.Context) error {
 	}
 
 	amqpSender, err := amqpSession.NewSender(
-		amqp.LinkReceiverSettle(amqp.ModeSecond),
+		amqp.LinkSenderSettle(amqp.ModeUnsettled),
 		amqp.LinkTargetAddress(s.getAddress()))
 	if err != nil {
 		log.For(ctx).Error(err)


### PR DESCRIPTION
When the sender is created, we were requesting the receiver (broker) to be in second mode (ack each message sent). This change ignores what SB returns for receiver mode and only specifies sender should be in unsettled mode (requires an ack from the receiver).

fixes #119 