### PR TITLE
Upgrade amqp-common to v2.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## `head`
 
+## `v0.9.1`
+- bump common version to v2.1.0
+
 ## `v0.9.0`
 - periodically refresh claims based auth for connections to resolve [issue #116](https://github.com/Azure/azure-service-bus-go/issues/116)
 - refactor management functionality for entities into composition structs

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Azure/azure-service-bus-go
 go 1.12
 
 require (
-	github.com/Azure/azure-amqp-common-go/v2 v2.0.1-0.20190619212702-9727f6e7bc50
+	github.com/Azure/azure-amqp-common-go/v2 v2.1.0
 	github.com/Azure/azure-sdk-for-go v30.1.0+incompatible
 	github.com/Azure/go-autorest v12.0.0+incompatible
 	github.com/devigned/tab v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0 h1:TKXjQSRS0/cCDrP7KvkgU6SmILtF/yV2TOs/02K/WZQ=
 contrib.go.opencensus.io/exporter/ocagent v0.5.0/go.mod h1:ImxhfLRpxoYiSq891pBrLVhN+qmP8BTVvdH2YLs7Gl0=
-github.com/Azure/azure-amqp-common-go/v2 v2.0.1-0.20190619212702-9727f6e7bc50 h1:KPO7ZDYTiAMfLuK1r9vS98LrfPCE0t83sKJjy27Csdc=
-github.com/Azure/azure-amqp-common-go/v2 v2.0.1-0.20190619212702-9727f6e7bc50/go.mod h1:dCWWW6Z0g9RTKMYUP03nMUHdqm71VFt323bTNYML0Mc=
+github.com/Azure/azure-amqp-common-go/v2 v2.1.0 h1:+QbFgmWCnPzdaRMfsI0Yb6GrRdBj5jVL8N3EXuEUcBQ=
+github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-sdk-for-go v29.0.0+incompatible h1:CYPU39ULbGjQBo3gXIqiWouK0C4F+Pt2Zx5CqGvqknE=
 github.com/Azure/azure-sdk-for-go v29.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v30.1.0+incompatible h1:HyYPft8wXpxMd0kfLtXo6etWcO+XuPbLkcgx9g2cqxU=
@@ -150,7 +150,5 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-pack.ag/amqp v0.11.1 h1:Hbj15aWwso+sgqKY7nJTYEeaUV8gx3+u1RUSZxeW0vA=
-pack.ag/amqp v0.11.1/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 pack.ag/amqp v0.11.2 h1:cuNDWLUTbKRtEZwhB0WQBXf9pGbm87pUBXQhvcFxBWg=
 pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -41,7 +41,7 @@ func (suite *serviceBusSuite) TestMessageIterator() {
 
 			q, err := ns.NewQueue(queueName)
 			defer func() {
-				q.Close(context.Background())
+				_ = q.Close(context.Background())
 			}()
 			suite.NoError(err)
 
@@ -197,6 +197,7 @@ func testMessageIteratorLargePageSize(ctx context.Context, t *testing.T, queue *
 	}
 
 	require.NoError(t, queue.Send(ctx, NewMessageFromString(newPayload(pageSize+1))))
+	time.Sleep(1 * time.Second)
 
 	got := uint32(0)
 	for {

--- a/namespace.go
+++ b/namespace.go
@@ -48,7 +48,7 @@ const (
 	//`
 
 	// Version is the semantic version number
-	Version = "0.9.0"
+	Version = "0.9.1"
 
 	rootUserAgent = "/golang-service-bus"
 )


### PR DESCRIPTION
 bump version of amqp-common to v2.1 so it's not based on a branch version of the common lib.

fixes #139 