### PR TITLE
MSI Support

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -135,6 +135,8 @@ func NamespaceWithWebSocket() NamespaceOption {
 //
 // 3. Managed Identity (MI): attempt to authenticate via the MI assigned to the Azure resource
 //
+//
+// The Azure Environment used can be specified using the name of the Azure Environment set in "AZURE_ENVIRONMENT" var.
 func NamespaceWithEnvironmentBinding(name string) NamespaceOption {
 	return func(ns *Namespace) error {
 		provider, err := aad.NewJWTProvider(

--- a/namespace.go
+++ b/namespace.go
@@ -125,8 +125,17 @@ func NamespaceWithWebSocket() NamespaceOption {
 	}
 }
 
-// NamespaceFromMSI configures a namespace from the environment (variables or MSI)
-func NamespaceFromMSI(name string) NamespaceOption {
+// NamespaceWithEnvironmentBinding configures a namespace using the environment details. It uses one of the following methods:
+//
+// 1. Client Credentials: attempt to authenticate with a Service Principal via "AZURE_TENANT_ID", "AZURE_CLIENT_ID" and
+//    "AZURE_CLIENT_SECRET"
+//
+// 2. Client Certificate: attempt to authenticate with a Service Principal via "AZURE_TENANT_ID", "AZURE_CLIENT_ID",
+//    "AZURE_CERTIFICATE_PATH" and "AZURE_CERTIFICATE_PASSWORD"
+//
+// 3. Managed Identity (MI): attempt to authenticate via the MI assigned to the Azure resource
+//
+func NamespaceWithEnvironmentBinding(name string) NamespaceOption {
 	return func(ns *Namespace) error {
 		provider, err := aad.NewJWTProvider(
 			aad.JWTProviderWithEnvironmentVars(),


### PR DESCRIPTION
Added NamespaceFromMSI function to support creating a namespace using Managed Service Identity.

This is a PR for [issue 136](https://github.com/Azure/azure-service-bus-go/issues/136)

Thanks @devigned 