### PR TITLE
Add retry when Sender fails to recover

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## `head`
+- add retry when Sender fails to recover
 
 ## `v0.9.1`
 - bump common version to v2.1.0


### PR DESCRIPTION
Related issue: #141 .

Possible risks:
- It depends on the `common.Retry` method to sleep for fixed seconds instead of the random one.
- `common.Retry` will execute the recover logic at once for the first time.