### PR TITLE
Batch disposition calls return nil rather than 0 value

### DIFF
--- a/batch_disposition.go
+++ b/batch_disposition.go
@@ -65,8 +65,8 @@ func (bdi *BatchDispositionIterator) Next() (uuid *uuid.UUID) {
 	return uuid
 }
 
-func (bdi *BatchDispositionIterator) doUpdate(ctx context.Context, ec entityConnector) BatchDispositionError {
-	batchError := BatchDispositionError{}
+func (bdi *BatchDispositionIterator) doUpdate(ctx context.Context, ec entityConnector) *BatchDispositionError {
+	var batchError *BatchDispositionError
 	for !bdi.Done() {
 		if id := bdi.Next(); id != nil {
 			m := &Message{
@@ -75,6 +75,9 @@ func (bdi *BatchDispositionIterator) doUpdate(ctx context.Context, ec entityConn
 			m.ec = ec
 			err := m.sendDisposition(ctx, bdi.Status)
 			if err != nil {
+				if batchError == nil {
+					batchError = new(BatchDispositionError)
+				}
 				batchError.Errors = append(batchError.Errors, DispositionError{
 					LockTokenID: id,
 					err:         err,

--- a/batch_disposition_test.go
+++ b/batch_disposition_test.go
@@ -46,7 +46,7 @@ func TestBatchDispositionUnsupportedStatus(t *testing.T) {
 		receivingEntity: newReceivingEntity(newEntity("foo", "bar", nil)),
 	}
 	err := subscription.SendBatchDisposition(context.Background(), bdi)
-	be := err.(BatchDispositionError)
+	be := err.(*BatchDispositionError)
 	assert.NotNil(t, be, fmt.Sprintf("Wrong error type %T", err))
 	assert.EqualErrorf(t, err, fmt.Sprintf("Operation failed, %d error(s) reported.", len(be.Errors)), err.Error())
 
@@ -54,4 +54,18 @@ func TestBatchDispositionUnsupportedStatus(t *testing.T) {
 		assert.NotNil(t, innerErr.UnWrap(), "Unwrapped error is nil")
 		assert.EqualErrorf(t, innerErr, "unsupported bulk disposition status \"suspended\"", innerErr.Error())
 	}
+}
+
+func TestBatchDispositiondoUpdateNoError(t *testing.T) {
+	//want done to return immediately on a call to Done
+	//so no error can be generated, we can do that by
+	//placing an empty slice for the lock tokens
+	bdi := BatchDispositionIterator{
+		LockTokenIDs: []*uuid.UUID{},
+	}
+
+	//using nil for the entity connector as it will never be called
+	result := bdi.doUpdate(context.Background(), nil)
+
+	assert.Nil(t, result, fmt.Sprintf("Expected a nil error to be returned got %v", result))
 }


### PR DESCRIPTION
Current implementation does not have a way [`SendBatchDisposition`](https://github.com/Azure/azure-service-bus-go/blob/master/entity.go#L207) won't return a `nil` error.

Switching to a pointer allows the use of `var` and adding a `nil` check before using `new` to create the object.

Another option was modifying `SendBatchDisposition` to check the length of the internal error collection of the `BatchIteratorError` but that did not seen correct.

Fixes #145 