### PR TITLE
Support send and receiving custom annotations in System Properties

### DIFF
--- a/azuredeploy.tf
+++ b/azuredeploy.tf
@@ -63,9 +63,9 @@ resource "random_string" "secret" {
 resource "azuread_application" "test" {
   count                       = data.azurerm_client_config.current.service_principal_application_id == "" ? 1 : 0
   name                        = "servicebustest"
-  homepage                    = "https://servicebustest"
-  identifier_uris             = ["https://servicebustest"]
-  reply_urls                  = ["https://servicebustest"]
+  homepage                    = "https://servicebustest-${random_string.name.result}"
+  identifier_uris             = ["https://servicebustest-${random_string.name.result}"]
+  reply_urls                  = ["https://servicebustest-${random_string.name.result}"]
   available_to_other_tenants  = false
   oauth2_allow_implicit_flow  = true
 }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## `v0.10.2`
 - add support for sending and receiving custom annotations
+- added some missing AMQP span attributes
+- fixed propagation of sender/receiver close context
+- don't panic on empty AMQP payloads
 
 ## `v0.10.1`
 - fix nil pointer dereference for concurrent uses of Send() [issue #149](https://github.com/Azure/azure-service-bus-go/issues/149)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v0.10.2`
+- add support for sending and receiving custom annotations
+
 ## `v0.10.1`
 - fix nil pointer dereference for concurrent uses of Send() [issue #149](https://github.com/Azure/azure-service-bus-go/issues/149)
 - fix nil pointer dereference when there are no listeners [PR #151](https://github.com/Azure/azure-service-bus-go/pull/151)

--- a/message_session.go
+++ b/message_session.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/rpc"
-	"github.com/devigned/tab"
 	"github.com/Azure/go-amqp"
+	"github.com/devigned/tab"
 )
 
 // MessageSession represents and allows for interaction with a Service Bus Session.

--- a/namespace.go
+++ b/namespace.go
@@ -49,7 +49,7 @@ const (
 	//`
 
 	// Version is the semantic version number
-	Version = "0.10.1"
+	Version = "0.10.2"
 
 	rootUserAgent = "/golang-service-bus"
 )

--- a/rpc.go
+++ b/rpc.go
@@ -32,8 +32,8 @@ import (
 
 	"github.com/Azure/azure-amqp-common-go/v3/rpc"
 	"github.com/Azure/azure-amqp-common-go/v3/uuid"
-	"github.com/devigned/tab"
 	"github.com/Azure/go-amqp"
+	"github.com/devigned/tab"
 )
 
 type (

--- a/session.go
+++ b/session.go
@@ -28,8 +28,8 @@ import (
 	"sync/atomic"
 
 	"github.com/Azure/azure-amqp-common-go/v3/uuid"
-	"github.com/devigned/tab"
 	"github.com/Azure/go-amqp"
+	"github.com/devigned/tab"
 )
 
 type (


### PR DESCRIPTION
Adds support for sending an receiving custom annotations on messages by adding an `Annotations` field to the `SystemProperties` present in the message. fixes #166 

### Fix or Enhancement?

enhancement

- [x] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: MacOS
- Go version: 1.13