### PR TITLE
Update to use build-in env

### DIFF
--- a/eng/integration_tests.yml
+++ b/eng/integration_tests.yml
@@ -50,8 +50,8 @@ steps:
     workingDirectory: '$(sdkPath)'
     env:
       ARM_SUBSCRIPTION_ID: $(go-live-azure-subscription-id)
-      ARM_CLIENT_ID: $(go-live-azure-client-id)
-      ARM_CLIENT_SECRET: $(go-live-azure-client-secret)
+      ARM_CLIENT_ID: $(go-live-sb-azure-client-id)
+      ARM_CLIENT_SECRET: $(go-live-sb-azure-client-secret)
       ARM_TENANT_ID: $(go-live-tenant-id)
       GO111MODULE: on
 

--- a/eng/integration_tests.yml
+++ b/eng/integration_tests.yml
@@ -41,11 +41,6 @@ steps:
       unzip /tmp/terraform.zip -d /tmp
       mkdir -p ~/bin
       export PATH="~/bin:$PATH"
-      export ARM_SUBSCRIPTION_ID=$(AZURE_SUBSCRIPTION_ID)
-      export ARM_CLIENT_ID=$(AZURE_CLIENT_ID)
-      export ARM_CLIENT_SECRET=$(AZURE_CLIENT_SECRET)
-      export ARM_TENANT_ID=$(AZURE_TENANT_ID)
-      export GO111MODULE=on
       make test-cover
       make destroy-sb
       gocov convert cover.out > coverage.json
@@ -53,6 +48,12 @@ steps:
       gocov-html < coverage.json > coverage.html
     displayName: 'Run Integration Tests'
     workingDirectory: '$(sdkPath)'
+    env:
+      ARM_SUBSCRIPTION_ID: $(go-live-azure-subscription-id)
+      ARM_CLIENT_ID: $(go-live-azure-client-id)
+      ARM_CLIENT_SECRET: $(go-live-azure-client-secret)
+      ARM_TENANT_ID: $(go-live-tenant-id)
+      GO111MODULE: on
 
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
This isn't _strictly_ necessary, as you could easily continue using the `EXPORT` to set the variables even using a kv variable group.

However, there is a built-in method provided by ADO that is quite elegant.