### PR TITLE
tell users they can't go higher than 5 minutes

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -26,6 +26,9 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"runtime"
+	"strings"
+
 	"github.com/Azure/azure-amqp-common-go/v3/aad"
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
 	"github.com/Azure/azure-amqp-common-go/v3/cbs"
@@ -34,8 +37,6 @@ import (
 	"github.com/Azure/go-amqp"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"nhooyr.io/websocket"
-	"runtime"
-	"strings"
 )
 
 const (
@@ -48,7 +49,7 @@ const (
 	//`
 
 	// Version is the semantic version number
-	Version = "0.10.7"
+	Version = "0.10.9"
 
 	rootUserAgent = "/golang-service-bus"
 

--- a/namespace.go
+++ b/namespace.go
@@ -48,7 +48,7 @@ const (
 	//`
 
 	// Version is the semantic version number
-	Version = "0.10.3"
+	Version = "0.10.7"
 
 	rootUserAgent = "/golang-service-bus"
 

--- a/subscription_manager.go
+++ b/subscription_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -512,6 +513,10 @@ func SubscriptionWithLockDuration(window *time.Duration) SubscriptionManagementO
 			duration := time.Duration(1 * time.Minute)
 			window = &duration
 		}
+		if *window > time.Duration(5*time.Minute) {
+			return fmt.Errorf("Lock duration must be shorter than 5 minutes got: %v", *window)
+		}
+
 		s.LockDuration = ptrString(durationTo8601Seconds(*window))
 		return nil
 	}


### PR DESCRIPTION
Today if you pass SubscriptionWithLockDuration a duration > 5 minutes you will just never get messages. 
Here I am attempting to fail faster.
Another alternative would be to have the put fail. 