### PR TITLE
Consolidate auth auto-refresh

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -276,9 +276,9 @@ func (ns *Namespace) negotiateClaim(ctx context.Context, client *amqp.Client, en
 						tab.For(refreshCtx).Error(err)
 						// if auth failed cancel auto-refresh
 						done()
-						return
+					} else {
+						timer.Reset(refreshDelay)
 					}
-					timer.Reset(refreshDelay)
 				}
 			}
 		}()

--- a/namespace.go
+++ b/namespace.go
@@ -28,6 +28,8 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/aad"
 	"github.com/Azure/azure-amqp-common-go/v3/auth"
@@ -36,6 +38,7 @@ import (
 	"github.com/Azure/azure-amqp-common-go/v3/sas"
 	"github.com/Azure/go-amqp"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/devigned/tab"
 	"nhooyr.io/websocket"
 )
 
@@ -68,6 +71,10 @@ type (
 		tlsConfig     *tls.Config
 		userAgent     string
 		useWebSocket  bool
+		// used to ensure only one goroutine is running for auth auto-refresh
+		initRefresh sync.Once
+		// populated with the result from auto-refresh, to be called elsewhere
+		cancelRefresh func()
 	}
 
 	// NamespaceOption provides structure for configuring a new Service Bus namespace
@@ -231,12 +238,43 @@ func (ns *Namespace) newClient(ctx context.Context) (*amqp.Client, error) {
 	return amqp.Dial(ns.getAMQPHostURI(), defaultConnOptions...)
 }
 
-func (ns *Namespace) negotiateClaim(ctx context.Context, client *amqp.Client, entityPath string) error {
+// negotiateClaim performs initial authentication and starts periodic refresh of credentials.
+// the returned func is to cancel() the refresh goroutine.
+func (ns *Namespace) negotiateClaim(ctx context.Context, client *amqp.Client, entityPath string) (func(), error) {
 	ctx, span := ns.startSpanFromContext(ctx, "sb.namespace.negotiateClaim")
 	defer span.End()
 
 	audience := ns.getEntityAudience(entityPath)
-	return cbs.NegotiateClaim(ctx, audience, client, ns.TokenProvider)
+	if err := cbs.NegotiateClaim(ctx, audience, client, ns.TokenProvider); err != nil {
+		return nil, err
+	}
+	ns.initRefresh.Do(func() {
+		// start the periodic refresh of credentials
+		refreshCtx, done := context.WithCancel(context.Background())
+		go func() {
+			for {
+				timer := time.NewTimer(15 * time.Minute)
+				select {
+				case <-refreshCtx.Done():
+					// stop timer and drain channel
+					if !timer.Stop() {
+						<-timer.C
+					}
+					return
+				case <-timer.C:
+					refreshCtx, span := ns.startSpanFromContext(refreshCtx, "sb.namespace.negotiateClaim.refresh")
+					defer span.End()
+					if err := cbs.NegotiateClaim(refreshCtx, audience, client, ns.TokenProvider); err != nil {
+						tab.For(refreshCtx).Error(err)
+						// if auth failed cancel auto-refresh
+						done()
+					}
+				}
+			}
+		}()
+		ns.cancelRefresh = done
+	})
+	return ns.cancelRefresh, nil
 }
 
 func (ns *Namespace) getWSSHostURI() string {

--- a/receiver.go
+++ b/receiver.go
@@ -121,8 +121,6 @@ func (ns *Namespace) NewReceiver(ctx context.Context, entityPath string, opts ..
 		return nil, err
 	}
 
-	r.periodicallyRefreshAuth()
-
 	return r, nil
 }
 
@@ -395,7 +393,7 @@ func (r *Receiver) newSessionAndLink(ctx context.Context) error {
 	}
 	r.client = client
 
-	err = r.namespace.negotiateClaim(ctx, client, r.entityPath)
+	r.doneRefreshingAuth, err = r.namespace.negotiateClaim(ctx, client, r.entityPath)
 	if err != nil {
 		tab.For(ctx).Error(err)
 		return err
@@ -455,37 +453,6 @@ func (r *Receiver) getSessionFilterLinkOption() (amqp.LinkOption, bool) {
 	}
 
 	return amqp.LinkSourceFilter(name, code, r.sessionID), true
-}
-
-func (r *Receiver) periodicallyRefreshAuth() {
-	ctx, done := context.WithCancel(context.Background())
-	r.doneRefreshingAuth = done
-
-	ctx, span := r.startConsumerSpanFromContext(ctx, "sb.Receiver.periodicallyRefreshAuth")
-	defer span.End()
-
-	doNegotiateClaimLocked := func(ctx context.Context, r *Receiver) {
-		r.clientMu.RLock()
-		defer r.clientMu.RUnlock()
-
-		if r.client != nil {
-			if err := r.namespace.negotiateClaim(ctx, r.client, r.entityPath); err != nil {
-				tab.For(ctx).Error(err)
-			}
-		}
-	}
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				time.Sleep(5 * time.Minute)
-				doNegotiateClaimLocked(ctx, r)
-			}
-		}
-	}()
 }
 
 func messageID(msg *amqp.Message) interface{} {

--- a/receiver.go
+++ b/receiver.go
@@ -52,7 +52,7 @@ type (
 		prefetch           uint32
 		DefaultDisposition DispositionAction
 		Closed             bool
-		doneRefreshingAuth func() <-chan struct{}
+		cancelAuthRefresh  func() <-chan struct{}
 	}
 
 	// ReceiverOption provides a structure for configuring receivers
@@ -141,8 +141,8 @@ func (r *Receiver) close(ctx context.Context) error {
 		r.doneListening()
 	}
 
-	if r.doneRefreshingAuth != nil {
-		<-r.doneRefreshingAuth()
+	if r.cancelAuthRefresh != nil {
+		<-r.cancelAuthRefresh()
 	}
 
 	r.Closed = true
@@ -393,7 +393,7 @@ func (r *Receiver) newSessionAndLink(ctx context.Context) error {
 	}
 	r.client = client
 
-	r.doneRefreshingAuth, err = r.namespace.negotiateClaim(ctx, client, r.entityPath)
+	r.cancelAuthRefresh, err = r.namespace.negotiateClaim(ctx, client, r.entityPath)
 	if err != nil {
 		tab.For(ctx).Error(err)
 		return err

--- a/receiver.go
+++ b/receiver.go
@@ -52,7 +52,7 @@ type (
 		prefetch           uint32
 		DefaultDisposition DispositionAction
 		Closed             bool
-		doneRefreshingAuth func()
+		doneRefreshingAuth func() <-chan struct{}
 	}
 
 	// ReceiverOption provides a structure for configuring receivers
@@ -142,7 +142,7 @@ func (r *Receiver) close(ctx context.Context) error {
 	}
 
 	if r.doneRefreshingAuth != nil {
-		r.doneRefreshingAuth()
+		<-r.doneRefreshingAuth()
 	}
 
 	r.Closed = true

--- a/rpc.go
+++ b/rpc.go
@@ -43,7 +43,7 @@ type (
 		clientMu           sync.RWMutex
 		sessionID          *string
 		isSessionFilterSet bool
-		doneRefreshingAuth func()
+		doneRefreshingAuth func() <-chan struct{}
 	}
 
 	rpcClientOption func(*rpcClient) error
@@ -78,7 +78,7 @@ func (r *rpcClient) Close() error {
 	r.clientMu.Lock()
 	defer r.clientMu.Unlock()
 	if r.doneRefreshingAuth != nil {
-		r.doneRefreshingAuth()
+		<-r.doneRefreshingAuth()
 	}
 
 	return r.client.Close()

--- a/rpc.go
+++ b/rpc.go
@@ -77,6 +77,9 @@ func (r *rpcClient) Recover(ctx context.Context) error {
 func (r *rpcClient) Close() error {
 	r.clientMu.Lock()
 	defer r.clientMu.Unlock()
+	if r.doneRefreshingAuth != nil {
+		r.doneRefreshingAuth()
+	}
 
 	return r.client.Close()
 }

--- a/sender.go
+++ b/sender.go
@@ -46,7 +46,7 @@ type (
 		entityPath         string
 		Name               string
 		sessionID          *string
-		doneRefreshingAuth func()
+		doneRefreshingAuth func() <-chan struct{}
 	}
 
 	// SendOption provides a way to customize a message on sending
@@ -118,7 +118,7 @@ func (s *Sender) Close(ctx context.Context) error {
 // closes the connection.  callers *must* hold the client write lock before calling!
 func (s *Sender) close(ctx context.Context) error {
 	if s.doneRefreshingAuth != nil {
-		s.doneRefreshingAuth()
+		<-s.doneRefreshingAuth()
 	}
 
 	var lastErr error


### PR DESCRIPTION
Moved the enabling of auth auto-refresh to when calling
negotiateClaim().  This ensures that all code paths that require
authentication will enable auto-refresh.
Ensure that there's only one goroutine that performs the refresh.
Changed auth refresh interval to 15 minutes per guideance from SB.
Exit auth auto-refresh goroutine if it fails; this should help trigger
recovering of clients due to failed authentication.