### PR TITLE
fix lock renewal test to take into account amqp flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Azure/azure-amqp-common-go/v3 v3.1.0
 	github.com/Azure/azure-sdk-for-go v51.1.0+incompatible
-	github.com/Azure/go-amqp v0.13.5
+	github.com/Azure/go-amqp v0.13.6
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/Azure/go-autorest/autorest/date v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/Azure/azure-amqp-common-go/v3 v3.1.0/go.mod h1:PBIGdzcO1teYoufTKMcGib
 github.com/Azure/azure-sdk-for-go v51.1.0+incompatible h1:7uk6GWtUqKg6weLv2dbKnzwb0ml1Qn70AdtRccZ543w=
 github.com/Azure/azure-sdk-for-go v51.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-amqp v0.13.0/go.mod h1:qj+o8xPCz9tMSbQ83Vp8boHahuRDl5mkNHyt1xlxUTs=
-github.com/Azure/go-amqp v0.13.5 h1:gUJVuxQCMjVJsL8gmol1yQ92oGYaRsscAk4ZJ0ltT9s=
-github.com/Azure/go-amqp v0.13.5/go.mod h1:wbpCKA8tR5MLgRyIu+bb+S6ECdIDdYJ0NlpFE9xsBPI=
+github.com/Azure/go-amqp v0.13.6 h1:CWjyY59Iyc1sO/fE/AubMLMWf5id+Uiw/ph0bZzG9Ns=
+github.com/Azure/go-amqp v0.13.6/go.mod h1:wbpCKA8tR5MLgRyIu+bb+S6ECdIDdYJ0NlpFE9xsBPI=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.3 h1:fyYnmYujkIXUgv88D9/Wo2ybE4Zwd/TmQd5sSI5u2Ws=

--- a/lockrenewal_test.go
+++ b/lockrenewal_test.go
@@ -1,5 +1,27 @@
 package servicebus
 
+//	MIT License
+//
+//	Copyright (c) Microsoft Corporation. All rights reserved.
+//
+//	Permission is hereby granted, free of charge, to any person obtaining a copy
+//	of this software and associated documentation files (the "Software"), to deal
+//	in the Software without restriction, including without limitation the rights
+//	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//	copies of the Software, and to permit persons to whom the Software is
+//	furnished to do so, subject to the following conditions:
+//
+//	The above copyright notice and this permission notice shall be included in all
+//	copies or substantial portions of the Software.
+//
+//	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//	SOFTWARE
+
 import (
 	"context"
 	"fmt"

--- a/lockrenewal_test.go
+++ b/lockrenewal_test.go
@@ -2,6 +2,7 @@ package servicebus
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -12,7 +13,7 @@ import (
 )
 
 func (suite *serviceBusSuite) TestQueueSendReceiveWithLock() {
-	tests := map[string]func(context.Context, *testing.T, *Queue){
+	tests := map[string]func(context.Context, *testing.T, *Queue, int){
 		"SimpleSendReceiveWithLock": testQueueSendAndReceiveWithRenewLock,
 	}
 
@@ -22,13 +23,14 @@ func (suite *serviceBusSuite) TestQueueSendReceiveWithLock() {
 			queueName := suite.randEntityName()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*300)
 			defer cancel()
-			lockDuration := 30 * time.Second
+			lockDuration := 10 * time.Second
 
 			cleanup := makeQueue(ctx, t, ns, queueName, QueueEntityWithLockDuration(&lockDuration))
-			q, err := ns.NewQueue(queueName)
+			numMessages := rand.Intn(40) + 10
+			q, err := ns.NewQueue(queueName, QueueWithPrefetchCount(uint32(numMessages)))
 			suite.NoError(err)
 			defer cleanup()
-			testFunc(ctx, t, q)
+			testFunc(ctx, t, q, numMessages)
 			suite.NoError(q.Close(ctx))
 			if !t.Failed() {
 				// If there are message on the queue this would mean that a lock wasn't held and the message was requeued.
@@ -39,17 +41,18 @@ func (suite *serviceBusSuite) TestQueueSendReceiveWithLock() {
 	}
 }
 
-func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, queue *Queue) {
+func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, queue *Queue, numMessages int) {
 	ttl := 5 * time.Minute
-	numMessages := rand.Intn(40) + 20
 	activeMessages := make([]*Message, 0, numMessages)
 	expected := make(map[string]int, numMessages)
 	seen := make(map[string]int, numMessages)
 	errs := make(chan error, 1)
 
-	renewEvery := time.Second * 20
-	processingTime := time.Second * 100
-
+	renewEvery := time.Second * 6
+	// all are held in memory. we wait a bit longer than the lock expiry set to 10s
+	processingTime := 15*time.Second
+	t.Logf("processing time : %s", processingTime)
+	fmt.Printf("processing time : %s \n", processingTime)
 	t.Logf("Sending/receiving %d messages", numMessages)
 
 	// Receiving Loop
@@ -59,7 +62,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 		errs <- queue.Receive(inner, HandlerFunc(func(ctx context.Context, msg *Message) error {
 			numSeen++
 			seen[string(msg.Data)]++
-
+			fmt.Printf("handling message %d - %s \n", numSeen, msg.LockToken)
 			activeMessages = append(activeMessages, msg)
 			if numSeen >= numMessages {
 				cancel()
@@ -81,6 +84,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 			if err != nil && runRenewal {
 				t.Error(err)
 			}
+			fmt.Printf("renewed locks successfuly for %d messages\n", len(activeMessages))
 		}
 	}()
 
@@ -100,6 +104,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 
 	// Then finally accept all the messages we're holding locks on
 	for _, msg := range activeMessages {
+		fmt.Printf("completing %d messages", len(activeMessages))
 		assert.NoError(t, msg.Complete(ctx))
 	}
 

--- a/lockrenewal_test.go
+++ b/lockrenewal_test.go
@@ -24,7 +24,6 @@ package servicebus
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -74,7 +73,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 	// all are held in memory. we wait a bit longer than the lock expiry set to 10s
 	processingTime := 15 * time.Second
 	t.Logf("processing time : %s", processingTime)
-	fmt.Printf("processing time : %s \n", processingTime)
+	t.Logf("processing time : %s \n", processingTime)
 	t.Logf("Sending/receiving %d messages", numMessages)
 
 	// Receiving Loop
@@ -84,7 +83,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 		errs <- queue.Receive(inner, HandlerFunc(func(ctx context.Context, msg *Message) error {
 			numSeen++
 			seen[string(msg.Data)]++
-			fmt.Printf("handling message %d - %s \n", numSeen, msg.LockToken)
+			t.Logf("handling message %d - %s \n", numSeen, msg.LockToken)
 			activeMessages = append(activeMessages, msg)
 			if numSeen >= numMessages {
 				cancel()
@@ -106,7 +105,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 			if err != nil && runRenewal {
 				t.Error(err)
 			}
-			fmt.Printf("renewed locks successfuly for %d messages\n", len(activeMessages))
+			t.Logf("renewed locks successfuly for %d messages\n", len(activeMessages))
 		}
 	}()
 
@@ -126,7 +125,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 
 	// Then finally accept all the messages we're holding locks on
 	for _, msg := range activeMessages {
-		fmt.Printf("completing %d messages", len(activeMessages))
+		t.Logf("completing %d messages", len(activeMessages))
 		assert.NoError(t, msg.Complete(ctx))
 	}
 

--- a/lockrenewal_test.go
+++ b/lockrenewal_test.go
@@ -50,7 +50,7 @@ func testQueueSendAndReceiveWithRenewLock(ctx context.Context, t *testing.T, que
 
 	renewEvery := time.Second * 6
 	// all are held in memory. we wait a bit longer than the lock expiry set to 10s
-	processingTime := 15*time.Second
+	processingTime := 15 * time.Second
 	t.Logf("processing time : %s", processingTime)
 	fmt.Printf("processing time : %s \n", processingTime)
 	t.Logf("Sending/receiving %d messages", numMessages)


### PR DESCRIPTION
[go-amqp now takes message dispostion into account to adjust the flow](https://github.com/Azure/go-amqp/pull/20)
this means that no credits are provided to the sender
until a disposition is sent for a given message.

previous test handled messages concurrently without completing them
and this won't work anymore, unless the prefetch is set higher.

