### PR TITLE
defer close the link!

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -119,55 +119,60 @@ func (r *rpcClient) doRPCWithRetry(ctx context.Context, address string, msg *amq
 	// track the number of times we attempt to perform the RPC call.
 	// this is to avoid a potential infinite loop if the returned error
 	// is always transient and Recover() doesn't fail.
-	sendCount := 0
-	var link *rpc.Link
-	defer func() {
-		if link == nil {
-			return
-		}
-		if err := link.Close(ctx); err != nil {
-			tab.For(ctx).Error(err)
-		}
-	}()
-	for {
-		r.clientMu.RLock()
-		client := r.client
-		r.clientMu.RUnlock()
+	var response *rpc.Response
+	var err error
+	for sendCount := 0; sendCount < amqpRetryDefaultTimes; sendCount++ {
+		response, err = func() (*rpc.Response, error) {
+			r.clientMu.RLock()
+			client := r.client
+			r.clientMu.RUnlock()
 
-		var rsp *rpc.Response
-		var err error
-		link, err = rpc.NewLink(client, address, opts...)
-		if err == nil {
-			rsp, err = link.RetryableRPC(ctx, times, delay, msg)
+			var link *rpc.Link
+			var rsp *rpc.Response
+			var err error
+			link, err = rpc.NewLink(client, address, opts...)
 			if err == nil {
-				return rsp, err
+				defer link.Close(ctx)
+				rsp, err = link.RetryableRPC(ctx, times, delay, msg)
+				if err == nil {
+					return rsp, err
+				}
 			}
-		}
-		if sendCount >= amqpRetryDefaultTimes || !isAMQPTransientError(ctx, err) {
-			return nil, err
-		}
-		sendCount++
-		// if we get here, recover and try again
-		tab.For(ctx).Debug("recovering RPC connection")
-		_, retryErr := common.Retry(amqpRetryDefaultTimes, amqpRetryDefaultDelay, func() (interface{}, error) {
-			ctx, sp := r.startProducerSpanFromContext(ctx, "sb.rpcClient.doRPCWithRetry.tryRecover")
-			defer sp.End()
-			if err := r.Recover(ctx); err == nil {
-				tab.For(ctx).Debug("recovered RPC connection")
-				return nil, nil
+			if sendCount >= amqpRetryDefaultTimes || !isAMQPTransientError(ctx, err) {
+				return nil, err
 			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			default:
-				return nil, common.Retryable(err.Error())
+			sendCount++
+			if err := r.rpcConnectionRecoverWithRetry(ctx, err); err != nil {
+				return nil, err
 			}
-		})
-		if retryErr != nil {
-			tab.For(ctx).Debug("RPC recovering retried, but error was unrecoverable")
-			return nil, retryErr
-		}
+			return rsp, err
+		}()
 	}
+	return response, err
+}
+
+func (r *rpcClient) rpcConnectionRecoverWithRetry(ctx context.Context, err error) error {
+	// if we get here, recover and try again
+	tab.For(ctx).Debug("recovering RPC connection")
+	_, retryErr := common.Retry(amqpRetryDefaultTimes, amqpRetryDefaultDelay, func() (interface{}, error) {
+		ctx, sp := r.startProducerSpanFromContext(ctx, "sb.rpcClient.doRPCWithRetry.tryRecover")
+		defer sp.End()
+		if err := r.Recover(ctx); err == nil {
+			tab.For(ctx).Debug("recovered RPC connection")
+			return nil, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			return nil, common.Retryable(err.Error())
+		}
+	})
+	if retryErr != nil {
+		tab.For(ctx).Debug("RPC recovering retried, but error was unrecoverable")
+		return retryErr
+	}
+	return nil
 }
 
 // returns true if the AMQP error is considered transient

--- a/rpc.go
+++ b/rpc.go
@@ -127,14 +127,10 @@ func (r *rpcClient) doRPCWithRetry(ctx context.Context, address string, msg *amq
 			client := r.client
 			r.clientMu.RUnlock()
 
-			var link *rpc.Link
-			var rsp *rpc.Response
-			var err error
-			link, err = rpc.NewLink(client, address, opts...)
+			link, err := rpc.NewLink(client, address, opts...)
 			if err == nil {
 				defer link.Close(ctx)
-				rsp, err = link.RetryableRPC(ctx, times, delay, msg)
-				if err == nil {
+				if rsp, err := link.RetryableRPC(ctx, times, delay, msg); err != nil {
 					return rsp, err
 				}
 			}
@@ -145,7 +141,7 @@ func (r *rpcClient) doRPCWithRetry(ctx context.Context, address string, msg *amq
 			if err := r.rpcConnectionRecoverWithRetry(ctx, err); err != nil {
 				return nil, err
 			}
-			return rsp, err
+			return nil, err
 		}()
 	}
 	return response, err


### PR DESCRIPTION
Servicebus allows a maximum of 5000 open sessions.
Because we don't close it after each calls, the sessions stay active until they reach an idle timeout and get closed by the remote peer.
if you have enough load, you will reach max sessions pretty quickly as this is called for each message disposition, lock renewal, or management operations.

A better optimization would be to keep a dediccated management session around to avoid opening and closing so many sessions (handshake overhead)